### PR TITLE
Add anonymous user for using padman without http authentication.

### DIFF
--- a/private/index.php
+++ b/private/index.php
@@ -67,7 +67,7 @@ if (isset($_GET['group'])) {
 $instance = new EtherpadLiteClient(API_KEY, API_URL);
 
 //$author_name = $_SERVER['PHP_AUTH_USER']; //$_SERVER['HTTP_AUTH_USER'];
-$author_cn = $_SERVER['PHP_AUTH_USER'];
+$author_cn = (isset($_SERVER['PHP_AUTH_USER']) ? $_SERVER['PHP_AUTH_USER'] : 'anonymous');
 if (file_exists("/home/" . $author_cn . "/.padname")) {
   $author_name = file_get_contents("/home/" . $author_cn . "/.padname");
 } else {


### PR DESCRIPTION
Without using http authentication, there appears an error on the main page because $_SERVER['PHP_AUTH_USER'] isn't defined in this case. My fix simply sets the username to "anonymous" in this case.