### PR TITLE
Add missing variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,29 @@ to config.inc.php and change the configuration appropriately.
 
 ## Server configuration
 
-The web server must redirect all requests to index.php. For example, with nginx:
+The web server must redirect all requests to index.php. Additionally, a htaccess
+authentication is required if only registered users should be able to create new
+pads. (This is the default configuration, see "ALLOW_ANON_PAD_CREATE" in config.php.)
+
+A configuration with authentication for nginx could look like:
 
 ```
-        location / {
-                try_files $uri $uri/ /index.php?$args;
-        }
+location / {
+  auth_basic "Padman";
+  auth_basic_user_file /path/to/the/pad/.htpasswd;
+
+  try_files $uri $uri/ /index.php?$args;
+}
 ```
 
-Or with Apache:
+And for Apache:
 
 ```
+AuthType Basic
+AuthName "Padman"
+AuthUserFile /path/to/the/pad/.htpasswd
+require valid-user
+                
 RewriteEngine On
 RewriteBase /
 RewriteRule ^index\.php$ - [L]

--- a/README.md
+++ b/README.md
@@ -3,6 +3,24 @@
 To install, git clone this repository into your www root. Rename config.inc.php.template 
 to config.inc.php and change the configuration appropriately.
 
+## Server configuration
+
+The web server must redirect all requests to index.php. For example, with nginx:
+
+```
+        location / {
+                try_files $uri $uri/ /index.php?$args;
+        }
+```
+
+Or with Apache:
+
+```
+RewriteEngine On
+RewriteBase /
+RewriteRule ^index\.php$ - [L]
+```
+
 ## Links
 
 * [etherpad-lite](https://github.com/ether/etherpad-lite/)

--- a/config.inc.php.template
+++ b/config.inc.php.template
@@ -19,6 +19,7 @@ define("ADD_GROUP_LINK", "mailto:admin@example.org?subject=Etherpad%20-%20Bitte%
 
 // modify the categories shown on the page
 $shown_groups = array("category1", "category2");
+$shown_groups_titles = array("Category1", "Category2");
 
 // set to non-empty to require a password for pad deletion
 define("DELETE_PASSWORD", "");

--- a/private/index.php
+++ b/private/index.php
@@ -50,6 +50,7 @@ $padurl = PAD_URL;
 
 $instance = new EtherpadLiteClient(API_KEY, API_URL);
 
+$allow_pad_create = false;
 if (isset($_SERVER['PHP_AUTH_USER']) || ALLOW_ANON_PAD_CREATE) $allow_pad_create = true;
 
 $author_cn = (isset($_SERVER['PHP_AUTH_USER']) ? $_SERVER['PHP_AUTH_USER'] : 'anonymous_'.substr(md5($_SERVER["REMOTE_ADDR"]),0,10));


### PR DESCRIPTION
The current master shows the following in the browser:

```
Notice: Undefined variable: shown_groups_titles in /.../padman/private/index.php on line 11

Warning: array_map(): Argument #2 should be an array in /.../padman/private/index.php on line 11

Warning: array_intersect(): Argument #1 is not an array in /.../padman/private/index.php on line 66

Warning: in_array() expects parameter 2 to be array, null given in /srv/.../padman/private/index.php on line 71
Fehler

Die Gruppe existiert nicht.
```
There is a configuration variable missing in the config template and another variable isn't initialized.

Besides: It's not absolutely clear for me what's the difference between $shown_groups and $shown_groups_titles. Maybe someone could clarify this.