### PR TITLE
Settings dialog is not active

### DIFF
--- a/private/css/pads.css
+++ b/private/css/pads.css
@@ -48,3 +48,8 @@ background: -moz-linear-gradient(top, #e2e2e2 0%, #dbdbdb 50%, #d1d1d1 51%, #fef
 }
 
 #pad_passw:invalid { outline:2px solid red;color:red; }
+
+.modal-dialog {
+  z-index: 1050;
+}
+


### PR DESCRIPTION
With current master, I can see the settings dialog, but not work with. Because the gray layer from bootstrap has a z-index of 1040 and the modal-dialog of "auto". Without the z-index patch attached, I cannot work with the dialog.

That's strange. I can't believe that this error would be undetected. Could somebody please verify the problem? What else could cause this error? In various browsers.